### PR TITLE
CLTmoji | change default emoji to trophy

### DIFF
--- a/components/CreateGameForm.tsx
+++ b/components/CreateGameForm.tsx
@@ -49,7 +49,7 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [description, setDescription] = useState<string>(
     game ? game.description : '',
   );
-  const [emoji, setEmoji] = useState<any>(game ? game.emoji : '😘');
+  const [emoji, setEmoji] = useState<any>(game ? game.emoji : '🏆');
   const [answer, setAnswer] = useState<any>(game ? game.answer : '');
   const [extendedAnswer, setExtendedAnswer] = useState<any>(
     game ? game.answer : '',


### PR DESCRIPTION
Change default game card emoji to trophy.

<img width="998" alt="Screen Shot 2020-02-25 at 3 45 52 PM" src="https://user-images.githubusercontent.com/14959590/75297967-108d1f00-57e6-11ea-858c-ca0565678f6d.png">
