### PR TITLE
CLT | center align headers on main

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -133,7 +133,7 @@ const Home = ({ questions, darkMode, loggedIn }) => (
             </Link>
           </div>
         </section>
-        <h2 className='f3 f-subheadline-l measure lh-title fw7'>
+        <h2 className='f3 f-subheadline-l measure lh-title fw7 flex justify-center'>
           Bets of the Week
         </h2>
         <section className='flex flex-wrap'>
@@ -159,7 +159,7 @@ const Home = ({ questions, darkMode, loggedIn }) => (
           </div> */}
         </section>
         <article>
-          <h2 className='f3 f-subheadline-l measure lh-title fw7'>
+          <h2 className='f3 f-subheadline-l measure lh-title fw7 flex justify-center'>
             New Releases
           </h2>
           <div className='cf pa2'>


### PR DESCRIPTION
This PR center aligns `Bets of the Week` and `New Releases`.
<img width="756" alt="Screen Shot 2020-03-21 at 1 40 38 PM" src="https://user-images.githubusercontent.com/14959590/77236240-12929580-6b7a-11ea-8c6a-e1d193293314.png">
