### PR TITLE
CLT | create odds payout logic

### DIFF
--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -236,7 +236,8 @@ const AdminDashboard: React.FC<SubmissionsProps> = ({
                   </tr>
                 );
               })
-              .reverse()}
+              .reverse()
+              .slice(0, 40)}
           </tbody>
         </table>
       </div>

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,6 +40,42 @@ export function formatPrice(number) {
   }).format(fnumber);
 }
 
+export const formatPriceWithFractionDigits = (amount) => {
+  const options = {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+  };
+  // if its a whole, dollar amount, leave off the .00
+  if (amount % 100 === 0) options.minimumFractionDigits = 0;
+  const formatter = new Intl.NumberFormat('en-US', options);
+  return formatter.format(amount / 100);
+};
+
+export const formatAmericanToDecimalOdds = (odds) => {
+  const floatingPointOdds = Math.abs(parseFloat(odds));
+  const positive = odds[0] === '+';
+  if (positive) {
+    return floatingPointOdds / 100 + 1;
+  } else {
+    return 100 / floatingPointOdds + 1;
+  }
+};
+
+export const exportDollarsToCents = (amount) => amount * 100;
+
+export const calculateTotalPayout = (odds = '+100', wager) => {
+  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const payOutTotal = wager * decimalOdds;
+  return exportDollarsToCents(payOutTotal);
+};
+
+export const calculateTotalPayoutWithCredits = (odds = '+100', wager) => {
+  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const payOutTotal = wager * decimalOdds - wager;
+  return exportDollarsToCents(payOutTotal);
+};
+
 export const sortGames = (a, b) => {
   const aname = a.answer.length === 0;
   const bname = b.answer.length === 0;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -44,36 +44,41 @@ export const formatPriceWithFractionDigits = (amount) => {
   const options = {
     style: 'currency',
     currency: 'USD',
-    minimumFractionDigits: 2,
+    minimumFractionDigits: 3,
   };
   // if its a whole, dollar amount, leave off the .00
   if (amount % 100 === 0) options.minimumFractionDigits = 0;
-  const formatter = new Intl.NumberFormat('en-US', options);
-  return formatter.format(amount / 100);
+  const formatter = new Intl.NumberFormat('en-US', options).format(
+    amount / 100,
+  );
+  if (formatter.includes('.')) {
+    return formatter.slice(0, -1);
+  }
+  return formatter;
 };
 
-export const formatAmericanToDecimalOdds = (odds) => {
+export const convertAmericanToDecimalOdds = (odds) => {
   const floatingPointOdds = Math.abs(parseFloat(odds));
   const positive = odds[0] === '+';
   if (positive) {
-    return floatingPointOdds / 100 + 1;
+    return (floatingPointOdds / 100 + 1).toPrecision(4);
   } else {
-    return 100 / floatingPointOdds + 1;
+    return (100 / floatingPointOdds + 1).toPrecision(4);
   }
 };
 
-export const exportDollarsToCents = (amount) => amount * 100;
+export const convertDollarsToCents = (amount) => amount * 100;
 
 export const calculateTotalPayout = (odds = '+100', wager) => {
-  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const decimalOdds = convertAmericanToDecimalOdds(odds);
   const payOutTotal = wager * decimalOdds;
-  return exportDollarsToCents(payOutTotal);
+  return convertDollarsToCents(payOutTotal);
 };
 
 export const calculateTotalPayoutWithCredits = (odds = '+100', wager) => {
-  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const decimalOdds = convertAmericanToDecimalOdds(odds);
   const payOutTotal = wager * decimalOdds - wager;
-  return exportDollarsToCents(payOutTotal);
+  return convertDollarsToCents(payOutTotal);
 };
 
 export const sortGames = (a, b) => {

--- a/pages/user/balance.js
+++ b/pages/user/balance.js
@@ -1,6 +1,7 @@
 import { getCookie } from '../../lib/session';
-import CardSection from '../../components/checkout/CardSection';
-import Head from 'next/head';
+// import CardSection from '../../components/checkout/CardSection';
+// import Head from 'next/head';
+import { styles } from '../../constants/styles';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SecuredPage from '../../hoc/securedPage';
@@ -8,26 +9,43 @@ import Wrapper from '../../components/layout/Wrapper';
 import absoluteUrl from 'next-absolute-url';
 import axios from 'axios';
 
-const Terms = (ctx) => {
-  const { user } = ctx;
+const Terms = () => {
+  // const { user } = ctx;
   const data = {
     description: 'Make money while putting your intuition on the line.',
-    header: `Add to Balance`,
   };
   return (
     <>
-      <Head>
+      {/* <Head>
         <script src='https://js.stripe.com/v3/'></script>
-      </Head>
-      <Wrapper data={data} className='measure-wide'>
+      </Head> */}
+      <Wrapper data={data}>
         <main className='black-80'>
           {/* <UserDashNavigation /> */}
           <div className='mw8 center pv3 ph3' id='dashboard'>
-            <section className='flex-m flex-l nl3-m nr3-m nl3-l nr3-l'>
+            <h3 className='f2 pt0 mw3 db tc measure lh-title fw9 mv5 mh2'>
+              Sorry, we&apos;re currently troubleshooting some bugs on the
+              card-processing side of things.
+            </h3>
+            <img
+              className='center db pb3 w-50-ns w-70'
+              src='https://media.giphy.com/media/l2Sq3Ezdhj0DB2D6g/giphy.gif'
+            />
+            <p className={`${styles.paragraph}`}>
+              In the meantime, we&apos;re currently offering payments via{' '}
+              <span className='b'>Cash App</span>,
+              <span className='b'>Venmo</span> or{' '}
+              <span className='b'>Paypal</span>. If interested shoot us an email
+              at{' '}
+              <a className='gray b' href='mailto:info@clouty.io'>
+                info@clouty.io
+              </a>
+            </p>
+            {/* <section className='flex-m flex-l nl3-m nr3-m nl3-l nr3-l'>
               <article className='w-100 w-75-l ph3-m ph3-l'>
                 <CardSection user={user} />
               </article>
-            </section>
+            </section> */}
           </div>
         </main>
       </Wrapper>

--- a/pages/user/index.js
+++ b/pages/user/index.js
@@ -1,4 +1,9 @@
-import { formatPrice } from '../../lib/helpers';
+import {
+  calculateTotalPayout,
+  calculateTotalPayoutWithCredits,
+  formatPrice,
+  formatPriceWithFractionDigits,
+} from '../../lib/helpers';
 import { getCookie } from '../../lib/session';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
@@ -15,6 +20,7 @@ const Terms = ({ balance, submissions, user }) => {
     description: 'Make money while putting your intuition on the line.',
     header: `Welcome, ${user.info.firstName}!`,
   };
+
   return (
     <Wrapper data={data} user={user}>
       <main>
@@ -83,10 +89,16 @@ const Terms = ({ balance, submissions, user }) => {
                                     Win
                                     <span className='pl1 sans-serif'>
                                       → <span className='f6'>+</span>
-                                      {formatPrice(
+                                      {formatPriceWithFractionDigits(
                                         game.usedCredit
-                                          ? game.wager
-                                          : game.wager * 2,
+                                          ? calculateTotalPayoutWithCredits(
+                                              game.odds,
+                                              game.wager,
+                                            )
+                                          : calculateTotalPayout(
+                                              game.odds,
+                                              game.wager,
+                                            ),
                                       )}
                                     </span>
                                   </span>

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -149,7 +149,7 @@ export const sendTextMessage = async (name, type, phoneNumber) => {
 };
 
 export const formatAmericanToDecimalOdds = (odds) => {
-  const floatingPointOdds = parseFloat(odds);
+  const floatingPointOdds = Math.abs(parseFloat(odds));
   const positive = odds[0] === '+';
   if (positive) {
     return floatingPointOdds / 100 + 1;

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -147,3 +147,27 @@ export const sendTextMessage = async (name, type, phoneNumber) => {
     console.error(error);
   }
 };
+
+export const formatAmericanToDecimalOdds = (odds) => {
+  const floatingPointOdds = parseFloat(odds);
+  const positive = odds[0] === '+';
+  if (positive) {
+    return floatingPointOdds / 100 + 1;
+  } else {
+    return 100 / floatingPointOdds + 1;
+  }
+};
+
+export const exportDollarsToCents = (amount) => amount * 100;
+
+export const calculateTotalPayout = (odds = '+100', wager) => {
+  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const payOutTotal = wager * decimalOdds;
+  return exportDollarsToCents(payOutTotal);
+};
+
+export const calculateTotalPayoutWithCredits = (odds = '+100', wager) => {
+  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const payOutTotal = wager * decimalOdds - wager;
+  return exportDollarsToCents(payOutTotal);
+};

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -148,26 +148,26 @@ export const sendTextMessage = async (name, type, phoneNumber) => {
   }
 };
 
-export const formatAmericanToDecimalOdds = (odds) => {
+export const convertAmericanToDecimalOdds = (odds) => {
   const floatingPointOdds = Math.abs(parseFloat(odds));
   const positive = odds[0] === '+';
   if (positive) {
-    return floatingPointOdds / 100 + 1;
+    return (floatingPointOdds / 100 + 1).toPrecision(4);
   } else {
-    return 100 / floatingPointOdds + 1;
+    return (100 / floatingPointOdds + 1).toPrecision(4);
   }
 };
 
-export const exportDollarsToCents = (amount) => amount * 100;
+export const convertDollarsToCents = (amount) => amount * 100;
 
 export const calculateTotalPayout = (odds = '+100', wager) => {
-  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const decimalOdds = convertAmericanToDecimalOdds(odds);
   const payOutTotal = wager * decimalOdds;
-  return exportDollarsToCents(payOutTotal);
+  return convertDollarsToCents(payOutTotal);
 };
 
 export const calculateTotalPayoutWithCredits = (odds = '+100', wager) => {
-  const decimalOdds = formatAmericanToDecimalOdds(odds);
+  const decimalOdds = convertAmericanToDecimalOdds(odds);
   const payOutTotal = wager * decimalOdds - wager;
-  return exportDollarsToCents(payOutTotal);
+  return convertDollarsToCents(payOutTotal);
 };

--- a/server/helpers/game.js
+++ b/server/helpers/game.js
@@ -35,21 +35,14 @@ const handlePayouts = async (entries, db) => {
     })
     .toArray();
   users = users.map((user) => {
-    const { stripe } = user;
     const queryUser = modifiedUsers.filter((modUser) => {
       return user._id === modUser._id;
     })[0];
     const increase = queryUser.credit ? queryUser.amount / 2 : queryUser.amount;
 
     return {
-      ...user,
-      stripe: {
-        ...stripe,
-        user: {
-          ...stripe.user,
-          balance: stripe.user.balance + increase,
-        },
-      },
+      _id: user._id,
+      increase,
     };
   });
   let ops = [];
@@ -58,7 +51,7 @@ const handlePayouts = async (entries, db) => {
       updateOne: {
         filter: { _id: user._id },
         update: {
-          $set: user,
+          $inc: { 'stripe.user.balance': user.increase },
         },
       },
     });


### PR DESCRIPTION
This PR adds logic to calculate user payout when using odds. It's also backwards compatible with previous "Even Money" bets before odds.

<img width="1680" alt="Screen Shot 2020-04-11 at 5 58 03 PM" src="https://user-images.githubusercontent.com/14959590/79058126-99d5a500-7c1e-11ea-8cfb-03725e7338bb.png">
