### PR TITLE
CLT | fix: update handle payouts to work for bets from same user

### DIFF
--- a/server/helpers/game.js
+++ b/server/helpers/game.js
@@ -17,17 +17,37 @@ import {
 } from '../helpers';
 import { loserEmailContent, winnerEmailContent } from '../emailTemplates';
 
-const handlePayouts = async (entries, db) => {
-  const modifiedUsers = entries.map((entry) => {
-    return {
-      _id: entry.userId,
-      amount: entry.usedCredit
-        ? calculateTotalPayoutWithCredits(entry.odds, entry.wager)
-        : calculateTotalPayout(entry.odds, entry.wager),
-      credit: entry.usedCredit,
-    };
-  });
+const reduceAndParseUsers = (users) => {
+  // TODO this logic could be handled in a join table
+  const reducedUsers = users.reduce((acc, value) => {
+    if (acc[value.userId]) {
+      const user = acc[value.userId];
+      user.amount += value.usedCredit
+        ? calculateTotalPayoutWithCredits(value.odds, value.wager)
+        : calculateTotalPayout(value.odds, value.wager);
+    } else {
+      acc[value.userId] = {
+        _id: value.userId,
+        amount: value.usedCredit
+          ? calculateTotalPayoutWithCredits(value.odds, value.wager)
+          : calculateTotalPayout(value.odds, value.wager),
+        credit: value.usedCredit,
+      };
+    }
+    return acc;
+  }, {});
 
+  const updateUsers = [];
+
+  for (const key in reducedUsers) {
+    updateUsers.push(reducedUsers[key]);
+  }
+
+  return updateUsers;
+};
+
+const handlePayouts = async (entries, db) => {
+  const updatedUsers = reduceAndParseUsers(entries);
   let users = await db
     .collection(user)
     .find({
@@ -39,7 +59,7 @@ const handlePayouts = async (entries, db) => {
     })
     .toArray();
   users = users.map((user) => {
-    const queryUser = modifiedUsers.filter((modUser) => {
+    const queryUser = updatedUsers.filter((modUser) => {
       return user._id === modUser._id;
     })[0];
 


### PR DESCRIPTION
This PR fixes a bug where multiple bets from the same user on a game were being overwritten. They're now being incremented and the total balance is now accurate.

<img width="952" alt="Screen Shot 2020-04-12 at 9 27 42 PM" src="https://user-images.githubusercontent.com/14959590/79092049-7553f880-7d04-11ea-8ad0-f1e147a39e4d.png">
