### PR TITLE
CLT | fix handle payouts logic

### DIFF
--- a/server/helpers/game.js
+++ b/server/helpers/game.js
@@ -43,10 +43,10 @@ const handlePayouts = async (entries, db) => {
       return user._id === modUser._id;
     });
 
-    let increase = 0;
-    queryUser.forEach((query) => {
-      increase += query.amount;
-    });
+    const increase = queryUser.reduce(
+      (acc, currentValue) => (acc += currentValue.amount),
+      0,
+    );
     return {
       _id: user._id,
       increase,

--- a/server/helpers/game.js
+++ b/server/helpers/game.js
@@ -41,11 +41,15 @@ const handlePayouts = async (entries, db) => {
   users = users.map((user) => {
     const queryUser = modifiedUsers.filter((modUser) => {
       return user._id === modUser._id;
-    })[0];
+    });
 
+    let increase = 0;
+    queryUser.forEach((query) => {
+      increase += query.credit ? query.amount / 2 : query.amount;
+    });
     return {
       _id: user._id,
-      balance: queryUser.amount,
+      increase,
     };
   });
   let ops = [];
@@ -54,7 +58,7 @@ const handlePayouts = async (entries, db) => {
       updateOne: {
         filter: { _id: user._id },
         update: {
-          $inc: { 'stripe.user.balance': user.balance },
+          $inc: { 'stripe.user.balance': user.increase },
         },
       },
     });

--- a/server/helpers/game.js
+++ b/server/helpers/game.js
@@ -45,7 +45,7 @@ const handlePayouts = async (entries, db) => {
 
     let increase = 0;
     queryUser.forEach((query) => {
-      increase += query.credit ? query.amount / 2 : query.amount;
+      increase += query.amount;
     });
     return {
       _id: user._id,


### PR DESCRIPTION
This PR fixes a bug where multiple bets from the same user on a game were being overwritten. They're now being incremented and the total balance is now accurate.
<img width="952" alt="Screen Shot 2020-04-12 at 9 27 42 PM" src="https://user-images.githubusercontent.com/14959590/79094808-848b7400-7d0d-11ea-8145-49278c474f47.png">
